### PR TITLE
feat: env vars as vectors

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,7 @@
 {:webserver/port #long #or [#env PORT 3001]
- :webserver/allowed-origins #or [#env ALLOWED_ORIGINS
-                                 ["http://docs.clj.codes" "https://docs.clj.codes"
-                                  "http://docs-frontend.fly.dev" "https://docs-frontend.fly.dev"]]
+ :webserver/allowed-origins #csv #or [#env ALLOWED_ORIGINS
+                                      ["http://docs.clj.codes" "https://docs.clj.codes"
+                                       "http://docs-frontend.fly.dev" "https://docs-frontend.fly.dev"]]
 
  :database {:dbtype "postgres"
             :dbname #or [#env DB_NAME "postgres"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,6 +1,7 @@
 {:webserver/port #long #or [#env PORT 3001]
- :webserver/allowed-origins ["http://docs.clj.codes" "https://docs.clj.codes"
-                             "http://docs-frontend.fly.dev" "https://docs-frontend.fly.dev"]
+ :webserver/allowed-origins #or [#env ALLOWED_ORIGINS
+                                 ["http://docs.clj.codes" "https://docs.clj.codes"
+                                  "http://docs-frontend.fly.dev" "https://docs-frontend.fly.dev"]]
 
  :database {:dbtype "postgres"
             :dbname #or [#env DB_NAME "postgres"]

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -14,8 +14,10 @@
   (let [target-config (get-in config nested-keys)]
     (if (string? target-config)
       (let [split-configs (-> target-config
-                              (string/split  #", "))
-            env-config (map string/trim split-configs)]
+                              (string/split  #","))
+            env-config (->> split-configs
+                            (map string/trim)
+                            (remove empty?))]
         (assoc-in config nested-keys env-config))
       config)))
 

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -10,12 +10,14 @@
 (defn- str-var->vector-var
   "Converts a string config variable to a vector of strings, when applicable.
        Environment variables are expected to be set as comma-separated values."
-  [config nested-keys]
-  (let [target-config (get-in config nested-keys)]
-    (if (string? target-config)
-      (let [env-config (clojure.string/split target-config  #", ")]
-        (assoc-in config nested-keys env-config))
-      config)))
+       [config nested-keys]
+       (let [target-config (get-in config nested-keys)]
+            (if (string? target-config)
+                (let [split-configs (-> target-config
+                                        (string/split  #", "))
+                      env-config (map string/trim split-configs)]
+                     (assoc-in config nested-keys env-config))
+                config)))
 
 (defn- resolved-envs-config
   [config str-envs]

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -1,0 +1,26 @@
+(ns codes.clj.docs.backend.config
+  (:require [clojure.string :as string]))
+
+(def vector-env-vars
+  "Nested keys for config variables with corresponding environment 
+      variables that can hold multiple values separated by commas, e.g.:
+      ALLOWED_ORIGINS=\"https://domain.a.com, https://domain.b.com\""
+  [[:config :webserver/allowed-origins]])
+
+(defn- str-var->vector-var
+  "Converts a string config variable to a vector of strings, when applicable.
+       Environment variables are expected to be set as comma-separated values."
+  [config nested-keys]
+  (let [target-config (get-in config nested-keys)]
+    (if (string? target-config)
+      (let [env-config (clojure.string/split target-config  #", ")]
+        (assoc-in config nested-keys env-config))
+      config)))
+
+(defn- resolved-envs-config
+  [config str-envs]
+  (reduce str-var->vector-var config str-envs))
+
+(defn config
+  [config]
+  (resolved-envs-config config vector-env-vars))

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -3,21 +3,21 @@
 
 (def vector-env-vars
   "Nested keys for config variables with corresponding environment 
-      variables that can hold multiple values separated by commas, e.g.:
-      ALLOWED_ORIGINS=\"https://domain.a.com, https://domain.b.com\""
+  variables that can hold multiple values separated by commas, e.g.:
+  ALLOWED_ORIGINS=\"https://domain.a.com, https://domain.b.com\""
   [[:config :webserver/allowed-origins]])
 
 (defn- str-var->vector-var
   "Converts a string config variable to a vector of strings, when applicable.
-       Environment variables are expected to be set as comma-separated values."
-       [config nested-keys]
-       (let [target-config (get-in config nested-keys)]
-            (if (string? target-config)
-                (let [split-configs (-> target-config
-                                        (string/split  #", "))
-                      env-config (map string/trim split-configs)]
-                     (assoc-in config nested-keys env-config))
-                config)))
+  Environment variables are expected to be set as comma-separated values."
+  [config nested-keys]
+  (let [target-config (get-in config nested-keys)]
+    (if (string? target-config)
+      (let [split-configs (-> target-config
+                              (string/split  #", "))
+            env-config (map string/trim split-configs)]
+        (assoc-in config nested-keys env-config))
+      config)))
 
 (defn- resolved-envs-config
   [config str-envs]

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -21,10 +21,8 @@
         (assoc-in config nested-keys env-config))
       config)))
 
-(defn- resolved-envs-config
-  [config str-envs]
-  (reduce str-var->vector-var config str-envs))
-
 (defn config
-  [config]
-  (resolved-envs-config config vector-env-vars))
+  ([config]
+   (reduce str-var->vector-var config vector-env-vars))
+  ([config vector-envs]
+   (reduce str-var->vector-var config vector-envs)))

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -1,20 +1,20 @@
 (ns codes.clj.docs.backend.config
-    (:require [aero.core :as aero]
-              [clojure.string :as string]))
+  (:require [aero.core :as aero]
+            [clojure.string :as string]))
 
 (defn- str-var->vector-var
   "Converts a string config variable to a vector of strings, when applicable.
   Environment variables are expected to be set as comma-separated values."
   [value]
   (if (string? value)
-      (let [split-configs (-> value
-                              (string/split  #","))
-            env-config (->> split-configs
-                            (map string/trim)
-                            (remove empty?))]
-        env-config)
-      value))
+    (let [split-configs (-> value
+                            (string/split  #","))
+          env-config (->> split-configs
+                          (map string/trim)
+                          (remove empty?))]
+      env-config)
+    value))
 
-(defmethod aero/reader 'csv 
+(defmethod aero/reader 'csv
   [_ _ value]
   (str-var->vector-var value))

--- a/src/codes/clj/docs/backend/config.clj
+++ b/src/codes/clj/docs/backend/config.clj
@@ -1,28 +1,20 @@
 (ns codes.clj.docs.backend.config
-  (:require [clojure.string :as string]))
-
-(def vector-env-vars
-  "Nested keys for config variables with corresponding environment 
-  variables that can hold multiple values separated by commas, e.g.:
-  ALLOWED_ORIGINS=\"https://domain.a.com, https://domain.b.com\""
-  [[:config :webserver/allowed-origins]])
+    (:require [aero.core :as aero]
+              [clojure.string :as string]))
 
 (defn- str-var->vector-var
   "Converts a string config variable to a vector of strings, when applicable.
   Environment variables are expected to be set as comma-separated values."
-  [config nested-keys]
-  (let [target-config (get-in config nested-keys)]
-    (if (string? target-config)
-      (let [split-configs (-> target-config
+  [value]
+  (if (string? value)
+      (let [split-configs (-> value
                               (string/split  #","))
             env-config (->> split-configs
                             (map string/trim)
                             (remove empty?))]
-        (assoc-in config nested-keys env-config))
-      config)))
+        env-config)
+      value))
 
-(defn config
-  ([config]
-   (reduce str-var->vector-var config vector-env-vars))
-  ([config vector-envs]
-   (reduce str-var->vector-var config vector-envs)))
+(defmethod aero/reader 'csv 
+  [_ _ value]
+  (str-var->vector-var value))

--- a/src/codes/clj/docs/backend/server.clj
+++ b/src/codes/clj/docs/backend/server.clj
@@ -1,5 +1,6 @@
 (ns codes.clj.docs.backend.server
   (:require [codes.clj.docs.backend.components.db-docs :as components.db-docs]
+            [codes.clj.docs.backend.config :as backend.config]
             [codes.clj.docs.backend.db.datalevin :refer [read-conn-opts]]
             [codes.clj.docs.backend.routes :as routes]
             [com.stuartsierra.component :as component]
@@ -16,7 +17,7 @@
 
 (defn base-system-map []
   (component/system-map
-   :config (config/new-config)
+   :config (backend.config/config (config/new-config))
    :http (http/new-http)
    :router (router/new-router routes/routes)
    :database (component/using (database/new-database) [:config])

--- a/src/codes/clj/docs/backend/server.clj
+++ b/src/codes/clj/docs/backend/server.clj
@@ -1,6 +1,6 @@
 (ns codes.clj.docs.backend.server
   (:require [codes.clj.docs.backend.components.db-docs :as components.db-docs]
-            [codes.clj.docs.backend.config :as backend.config]
+            [codes.clj.docs.backend.config]
             [codes.clj.docs.backend.db.datalevin :refer [read-conn-opts]]
             [codes.clj.docs.backend.routes :as routes]
             [com.stuartsierra.component :as component]
@@ -17,7 +17,7 @@
 
 (defn base-system-map []
   (component/system-map
-   :config (backend.config/config (config/new-config))
+   :config (config/new-config)
    :http (http/new-http)
    :router (router/new-router routes/routes)
    :database (component/using (database/new-database) [:config])

--- a/test/resources/csv-config.edn
+++ b/test/resources/csv-config.edn
@@ -1,0 +1,3 @@
+{:some-config #csv #or [#env SOME "value1, value2"]
+ :malformed-config #csv #or [#env MALFORMED "value3,   value4,value5, "]
+ :trailing-comma-config #csv #or [#env TRAILING_COMMA "value6, value7,"]}

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -8,21 +8,21 @@
 (use-fixtures :once helpers.malli/with-intrumentation)
 
 (deftest str-var->vector-var-test
-         (testing "root-level configs should be converted to vectors"
-                  (is (match? ["value1" "value2"]
-                              (#'backend.config/str-var->vector-var "value1, value2"))))
+  (testing "csv configs should be converted to vectors"
+    (is (match? ["value1" "value2"]
+                (#'backend.config/str-var->vector-var "value1, value2"))))
 
-         (testing "trailing and extra whitespaces should be ignored"
-                  (is (match? ["value3" "value4" "value5"]
-                              (#'backend.config/str-var->vector-var "value3,   value4,value5, "))))
+  (testing "trailing and extra whitespaces should be ignored"
+    (is (match? ["value3" "value4" "value5"]
+                (#'backend.config/str-var->vector-var "value3,   value4,value5, "))))
 
-         (testing "trailing commas should be ignored"
-                  (is (match? ["value6" "value7"]
-                              (#'backend.config/str-var->vector-var "value6, value7,")))))
+  (testing "trailing commas should be ignored"
+    (is (match? ["value6" "value7"]
+                (#'backend.config/str-var->vector-var "value6, value7,")))))
 
 (deftest csv-reader-test
-         (testing "tag literal #csv should turn comma-separated strings into vectors"
-                  (is (match? {:some-config ["value1" "value2"]
-                               :malformed-config ["value3" "value4" "value5"]
-                               :trailing-comma-config ["value6" "value7"]}
-                              (aero/read-config "test/resources/csv-config.edn")))))
+  (testing "tag literal #csv should turn comma-separated strings into vectors"
+    (is (match? {:some-config ["value1" "value2"]
+                 :malformed-config ["value3" "value4" "value5"]
+                 :trailing-comma-config ["value6" "value7"]}
+                (aero/read-config "test/resources/csv-config.edn")))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -16,42 +16,49 @@
 
 (deftest str-var->vector-var-test
   (let [system (create-and-start-system!
-                {:config (config.aero/new-config {:some-config "value1, value2"
-                                                  :another-config {:nested-config
-                                                                   "value3, value4"}})})
+                {:config (config.aero/new-config {:some-config "value1, value2" 
+                                                  :another-config 
+                                                  {:nested-config "value3, value4"}
+                                                  :malformed-config "value5,   value6, "})})
         config-component (:config system)]
 
-    (testing "root-level configs should be converted to vectors"
-      (is (match? {:config {:some-config ["value1" "value2"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :some-config]))))
+       (testing "root-level configs should be converted to vectors"
+                (is (match? {:config {:some-config ["value1" "value2"]}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :some-config]))))
 
-    (testing "nested configs should be converted to vectors"
-      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :another-config :nested-config]))))
+       (testing "nested configs should be converted to vectors"
+                (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :another-config :nested-config]))))
 
-    (let [vector-env-vars [[:config :some-config]
-                           [:config :another-config :nested-config]]
-          no-matching-env-vars [[:config :non-existent-config]]]
+       (testing "trailing commas and extra whitespaces are ignored"
+                (is (match? {:config {:malformed-config ["value5" "value6"]}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :malformed-config]))))
 
-      (testing "all defined vector-env-vars should be processed"
-        (is (match? {:config (embeds {:some-config ["value1" "value2"],
-                                      :another-config {:nested-config
-                                                       ["value3" "value4"]}})}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           vector-env-vars))))
+       (let [vector-env-vars [[:config :some-config]
+                              [:config :another-config :nested-config]
+                              [:config :malformed-config]]
+             no-matching-env-vars [[:config :non-existent-config]]
+             converted-configs {:some-config ["value1" "value2"],
+                                :another-config {:nested-config ["value3" "value4"]}
+                                :malformed-config ["value5" "value6"]}
+             unaltered-configs {:some-config "value1, value2",
+                                :another-config {:nested-config "value3, value4"}
+                                :malformed-config "value5,   value6, "}]
 
-      (testing "when vector-env-vars is empty, the config should be left unaltered"
-        (is (match? {:config (embeds {:some-config "value1, value2",
-                                      :another-config {:nested-config
-                                                       "value3, value4"}})}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           []))))
+            (testing "all defined vector-env-vars should be processed"
+                     (is (match? {:config (embeds converted-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        vector-env-vars))))
 
-      (testing "when vector-env-vars has no matches, the config should be left unaltered"
-        (is (match? {:config (embeds {:some-config "value1, value2",
-                                      :another-config {:nested-config
-                                                       "value3, value4"}})}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           no-matching-env-vars)))))))
+            (testing "when vector-env-vars is empty, the config should be left unaltered"
+                     (is (match? {:config (embeds unaltered-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        []))))
+
+            (testing "when vector-env-vars has no matches, the config should be left unaltered"
+                     (is (match? {:config (embeds unaltered-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -19,46 +19,55 @@
                 {:config (config.aero/new-config {:some-config "value1, value2"
                                                   :another-config
                                                   {:nested-config "value3, value4"}
-                                                  :malformed-config "value5,   value6, "})})
+                                                  :malformed-config "value5,   value6,value7, "
+                                                  :trailing-comma "value8, value9,"})})
         config-component (:config system)]
 
-    (testing "root-level configs should be converted to vectors"
-      (is (match? {:config {:some-config ["value1" "value2"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :some-config]))))
+       (testing "root-level configs should be converted to vectors"
+                (is (match? {:config {:some-config ["value1" "value2"]}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :some-config]))))
 
-    (testing "nested configs should be converted to vectors"
-      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :another-config :nested-config]))))
+       (testing "nested configs should be converted to vectors"
+                (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :another-config :nested-config]))))
 
-    (testing "trailing commas and extra whitespaces are ignored"
-      (is (match? {:config {:malformed-config ["value5" "value6"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :malformed-config]))))
+       (testing "trailing and extra whitespaces should be ignored"
+                (is (match? {:config {:malformed-config ["value5" "value6" "value7"]}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :malformed-config]))))
 
-    (let [vector-env-vars [[:config :some-config]
-                           [:config :another-config :nested-config]
-                           [:config :malformed-config]]
-          no-matching-env-vars [[:config :non-existent-config]]
-          converted-configs {:some-config ["value1" "value2"],
-                             :another-config {:nested-config ["value3" "value4"]}
-                             :malformed-config ["value5" "value6"]}
-          unaltered-configs {:some-config "value1, value2",
-                             :another-config {:nested-config "value3, value4"}
-                             :malformed-config "value5,   value6, "}]
+       (testing "trailing commas should be ignored"
+                (is (match? {:config {:trailing-comma ["value8" "value9"]}}
+                            (#'backend.config/str-var->vector-var
+                             config-component [:config :trailing-comma]))))
 
-      (testing "all defined vector-env-vars should be processed"
-        (is (match? {:config (embeds converted-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           vector-env-vars))))
+       (let [vector-env-vars [[:config :some-config]
+                              [:config :another-config :nested-config]
+                              [:config :malformed-config]
+                              [:config :trailing-comma]]
+             no-matching-env-vars [[:config :non-existent-config]]
+             converted-configs {:some-config ["value1" "value2"],
+                                :another-config {:nested-config ["value3" "value4"]}
+                                :malformed-config ["value5" "value6" "value7"]
+                                :trailing-comma ["value8" "value9"]}
+             unaltered-configs {:some-config "value1, value2",
+                                :another-config {:nested-config "value3, value4"}
+                                :malformed-config "value5,   value6,value7, "
+                                :trailing-comma "value8, value9,"}]
 
-      (testing "when vector-env-vars is empty, the config should be left unaltered"
-        (is (match? {:config (embeds unaltered-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           []))))
+            (testing "all defined vector-env-vars should be processed"
+                     (is (match? {:config (embeds converted-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        vector-env-vars))))
 
-      (testing "when vector-env-vars has no matches, the config should be left unaltered"
-        (is (match? {:config (embeds unaltered-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           no-matching-env-vars)))))))
+            (testing "when vector-env-vars is empty, the config should be left unaltered"
+                     (is (match? {:config (embeds unaltered-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        []))))
+
+            (testing "when vector-env-vars has no matches, the config should be left unaltered"
+                     (is (match? {:config (embeds unaltered-configs)}
+                                 (#'backend.config/resolved-envs-config config-component
+                                                                        no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -1,0 +1,57 @@
+(ns unit.codes.clj.docs.backend.config-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [codes.clj.docs.backend.config :as backend.config]
+            [com.stuartsierra.component :as component]
+            [matcher-combinators.matchers :refer [embeds]]
+            [matcher-combinators.test :refer [match?]]
+            [parenthesin.components.config.aero :as config.aero]
+            [parenthesin.helpers.malli :as helpers.malli]))
+
+(use-fixtures :once helpers.malli/with-intrumentation)
+
+(defn- create-and-start-system!
+  [{:keys [config]}]
+  (component/start-system
+   (component/system-map :config config)))
+
+(deftest str-var->vector-var-test
+  (let [system (create-and-start-system!
+                {:config (config.aero/new-config {:some-config "value1, value2"
+                                                  :another-config {:nested-config
+                                                                   "value3, value4"}})})
+        config-component (:config system)]
+
+    (testing "root-level configs should be converted to vectors"
+      (is (match? {:config {:some-config ["value1" "value2"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :some-config]))))
+
+    (testing "nested configs should be converted to vectors"
+      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :another-config :nested-config]))))
+
+    (let [vector-env-vars [[:config :some-config]
+                           [:config :another-config :nested-config]]
+          no-matching-env-vars [[:config :non-existent-config]]]
+
+      (testing "all defined vector-env-vars should be processed"
+        (is (match? {:config (embeds {:some-config ["value1" "value2"],
+                                      :another-config {:nested-config
+                                                       ["value3" "value4"]}})}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           vector-env-vars))))
+
+      (testing "when vector-env-vars is empty, the config should be left unaltered"
+        (is (match? {:config (embeds {:some-config "value1, value2",
+                                      :another-config {:nested-config
+                                                       "value3, value4"}})}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           []))))
+
+      (testing "when vector-env-vars has no matches, the config should be left unaltered"
+        (is (match? {:config (embeds {:some-config "value1, value2",
+                                      :another-config {:nested-config
+                                                       "value3, value4"}})}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -59,15 +59,13 @@
 
       (testing "all defined vector-env-vars should be processed"
         (is (match? {:config (embeds converted-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           vector-env-vars))))
+                    (backend.config/config config-component vector-env-vars))))
 
       (testing "when vector-env-vars is empty, the config should be left unaltered"
         (is (match? {:config (embeds unaltered-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           []))))
+                    (backend.config/config config-component []))))
 
       (testing "when vector-env-vars has no matches, the config should be left unaltered"
         (is (match? {:config (embeds unaltered-configs)}
-                    (#'backend.config/resolved-envs-config config-component
-                                                           no-matching-env-vars)))))))
+                    (backend.config/config config-component
+                                           no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -23,51 +23,51 @@
                                                   :trailing-comma "value8, value9,"})})
         config-component (:config system)]
 
-       (testing "root-level configs should be converted to vectors"
-                (is (match? {:config {:some-config ["value1" "value2"]}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :some-config]))))
+    (testing "root-level configs should be converted to vectors"
+      (is (match? {:config {:some-config ["value1" "value2"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :some-config]))))
 
-       (testing "nested configs should be converted to vectors"
-                (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :another-config :nested-config]))))
+    (testing "nested configs should be converted to vectors"
+      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :another-config :nested-config]))))
 
-       (testing "trailing and extra whitespaces should be ignored"
-                (is (match? {:config {:malformed-config ["value5" "value6" "value7"]}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :malformed-config]))))
+    (testing "trailing and extra whitespaces should be ignored"
+      (is (match? {:config {:malformed-config ["value5" "value6" "value7"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :malformed-config]))))
 
-       (testing "trailing commas should be ignored"
-                (is (match? {:config {:trailing-comma ["value8" "value9"]}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :trailing-comma]))))
+    (testing "trailing commas should be ignored"
+      (is (match? {:config {:trailing-comma ["value8" "value9"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :trailing-comma]))))
 
-       (let [vector-env-vars [[:config :some-config]
-                              [:config :another-config :nested-config]
-                              [:config :malformed-config]
-                              [:config :trailing-comma]]
-             no-matching-env-vars [[:config :non-existent-config]]
-             converted-configs {:some-config ["value1" "value2"],
-                                :another-config {:nested-config ["value3" "value4"]}
-                                :malformed-config ["value5" "value6" "value7"]
-                                :trailing-comma ["value8" "value9"]}
-             unaltered-configs {:some-config "value1, value2",
-                                :another-config {:nested-config "value3, value4"}
-                                :malformed-config "value5,   value6,value7, "
-                                :trailing-comma "value8, value9,"}]
+    (let [vector-env-vars [[:config :some-config]
+                           [:config :another-config :nested-config]
+                           [:config :malformed-config]
+                           [:config :trailing-comma]]
+          no-matching-env-vars [[:config :non-existent-config]]
+          converted-configs {:some-config ["value1" "value2"],
+                             :another-config {:nested-config ["value3" "value4"]}
+                             :malformed-config ["value5" "value6" "value7"]
+                             :trailing-comma ["value8" "value9"]}
+          unaltered-configs {:some-config "value1, value2",
+                             :another-config {:nested-config "value3, value4"}
+                             :malformed-config "value5,   value6,value7, "
+                             :trailing-comma "value8, value9,"}]
 
-            (testing "all defined vector-env-vars should be processed"
-                     (is (match? {:config (embeds converted-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        vector-env-vars))))
+      (testing "all defined vector-env-vars should be processed"
+        (is (match? {:config (embeds converted-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           vector-env-vars))))
 
-            (testing "when vector-env-vars is empty, the config should be left unaltered"
-                     (is (match? {:config (embeds unaltered-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        []))))
+      (testing "when vector-env-vars is empty, the config should be left unaltered"
+        (is (match? {:config (embeds unaltered-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           []))))
 
-            (testing "when vector-env-vars has no matches, the config should be left unaltered"
-                     (is (match? {:config (embeds unaltered-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        no-matching-env-vars)))))))
+      (testing "when vector-env-vars has no matches, the config should be left unaltered"
+        (is (match? {:config (embeds unaltered-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -16,49 +16,49 @@
 
 (deftest str-var->vector-var-test
   (let [system (create-and-start-system!
-                {:config (config.aero/new-config {:some-config "value1, value2" 
-                                                  :another-config 
+                {:config (config.aero/new-config {:some-config "value1, value2"
+                                                  :another-config
                                                   {:nested-config "value3, value4"}
                                                   :malformed-config "value5,   value6, "})})
         config-component (:config system)]
 
-       (testing "root-level configs should be converted to vectors"
-                (is (match? {:config {:some-config ["value1" "value2"]}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :some-config]))))
+    (testing "root-level configs should be converted to vectors"
+      (is (match? {:config {:some-config ["value1" "value2"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :some-config]))))
 
-       (testing "nested configs should be converted to vectors"
-                (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :another-config :nested-config]))))
+    (testing "nested configs should be converted to vectors"
+      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :another-config :nested-config]))))
 
-       (testing "trailing commas and extra whitespaces are ignored"
-                (is (match? {:config {:malformed-config ["value5" "value6"]}}
-                            (#'backend.config/str-var->vector-var
-                             config-component [:config :malformed-config]))))
+    (testing "trailing commas and extra whitespaces are ignored"
+      (is (match? {:config {:malformed-config ["value5" "value6"]}}
+                  (#'backend.config/str-var->vector-var
+                   config-component [:config :malformed-config]))))
 
-       (let [vector-env-vars [[:config :some-config]
-                              [:config :another-config :nested-config]
-                              [:config :malformed-config]]
-             no-matching-env-vars [[:config :non-existent-config]]
-             converted-configs {:some-config ["value1" "value2"],
-                                :another-config {:nested-config ["value3" "value4"]}
-                                :malformed-config ["value5" "value6"]}
-             unaltered-configs {:some-config "value1, value2",
-                                :another-config {:nested-config "value3, value4"}
-                                :malformed-config "value5,   value6, "}]
+    (let [vector-env-vars [[:config :some-config]
+                           [:config :another-config :nested-config]
+                           [:config :malformed-config]]
+          no-matching-env-vars [[:config :non-existent-config]]
+          converted-configs {:some-config ["value1" "value2"],
+                             :another-config {:nested-config ["value3" "value4"]}
+                             :malformed-config ["value5" "value6"]}
+          unaltered-configs {:some-config "value1, value2",
+                             :another-config {:nested-config "value3, value4"}
+                             :malformed-config "value5,   value6, "}]
 
-            (testing "all defined vector-env-vars should be processed"
-                     (is (match? {:config (embeds converted-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        vector-env-vars))))
+      (testing "all defined vector-env-vars should be processed"
+        (is (match? {:config (embeds converted-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           vector-env-vars))))
 
-            (testing "when vector-env-vars is empty, the config should be left unaltered"
-                     (is (match? {:config (embeds unaltered-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        []))))
+      (testing "when vector-env-vars is empty, the config should be left unaltered"
+        (is (match? {:config (embeds unaltered-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           []))))
 
-            (testing "when vector-env-vars has no matches, the config should be left unaltered"
-                     (is (match? {:config (embeds unaltered-configs)}
-                                 (#'backend.config/resolved-envs-config config-component
-                                                                        no-matching-env-vars)))))))
+      (testing "when vector-env-vars has no matches, the config should be left unaltered"
+        (is (match? {:config (embeds unaltered-configs)}
+                    (#'backend.config/resolved-envs-config config-component
+                                                           no-matching-env-vars)))))))

--- a/test/unit/codes/clj/docs/backend/config_test.clj
+++ b/test/unit/codes/clj/docs/backend/config_test.clj
@@ -1,71 +1,28 @@
 (ns unit.codes.clj.docs.backend.config-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [aero.core :as aero]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [codes.clj.docs.backend.config :as backend.config]
-            [com.stuartsierra.component :as component]
-            [matcher-combinators.matchers :refer [embeds]]
             [matcher-combinators.test :refer [match?]]
-            [parenthesin.components.config.aero :as config.aero]
             [parenthesin.helpers.malli :as helpers.malli]))
 
 (use-fixtures :once helpers.malli/with-intrumentation)
 
-(defn- create-and-start-system!
-  [{:keys [config]}]
-  (component/start-system
-   (component/system-map :config config)))
-
 (deftest str-var->vector-var-test
-  (let [system (create-and-start-system!
-                {:config (config.aero/new-config {:some-config "value1, value2"
-                                                  :another-config
-                                                  {:nested-config "value3, value4"}
-                                                  :malformed-config "value5,   value6,value7, "
-                                                  :trailing-comma "value8, value9,"})})
-        config-component (:config system)]
+         (testing "root-level configs should be converted to vectors"
+                  (is (match? ["value1" "value2"]
+                              (#'backend.config/str-var->vector-var "value1, value2"))))
 
-    (testing "root-level configs should be converted to vectors"
-      (is (match? {:config {:some-config ["value1" "value2"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :some-config]))))
+         (testing "trailing and extra whitespaces should be ignored"
+                  (is (match? ["value3" "value4" "value5"]
+                              (#'backend.config/str-var->vector-var "value3,   value4,value5, "))))
 
-    (testing "nested configs should be converted to vectors"
-      (is (match? {:config {:another-config {:nested-config ["value3" "value4"]}}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :another-config :nested-config]))))
+         (testing "trailing commas should be ignored"
+                  (is (match? ["value6" "value7"]
+                              (#'backend.config/str-var->vector-var "value6, value7,")))))
 
-    (testing "trailing and extra whitespaces should be ignored"
-      (is (match? {:config {:malformed-config ["value5" "value6" "value7"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :malformed-config]))))
-
-    (testing "trailing commas should be ignored"
-      (is (match? {:config {:trailing-comma ["value8" "value9"]}}
-                  (#'backend.config/str-var->vector-var
-                   config-component [:config :trailing-comma]))))
-
-    (let [vector-env-vars [[:config :some-config]
-                           [:config :another-config :nested-config]
-                           [:config :malformed-config]
-                           [:config :trailing-comma]]
-          no-matching-env-vars [[:config :non-existent-config]]
-          converted-configs {:some-config ["value1" "value2"],
-                             :another-config {:nested-config ["value3" "value4"]}
-                             :malformed-config ["value5" "value6" "value7"]
-                             :trailing-comma ["value8" "value9"]}
-          unaltered-configs {:some-config "value1, value2",
-                             :another-config {:nested-config "value3, value4"}
-                             :malformed-config "value5,   value6,value7, "
-                             :trailing-comma "value8, value9,"}]
-
-      (testing "all defined vector-env-vars should be processed"
-        (is (match? {:config (embeds converted-configs)}
-                    (backend.config/config config-component vector-env-vars))))
-
-      (testing "when vector-env-vars is empty, the config should be left unaltered"
-        (is (match? {:config (embeds unaltered-configs)}
-                    (backend.config/config config-component []))))
-
-      (testing "when vector-env-vars has no matches, the config should be left unaltered"
-        (is (match? {:config (embeds unaltered-configs)}
-                    (backend.config/config config-component
-                                           no-matching-env-vars)))))))
+(deftest csv-reader-test
+         (testing "tag literal #csv should turn comma-separated strings into vectors"
+                  (is (match? {:some-config ["value1" "value2"]
+                               :malformed-config ["value3" "value4" "value5"]
+                               :trailing-comma-config ["value6" "value7"]}
+                              (aero/read-config "test/resources/csv-config.edn")))))


### PR DESCRIPTION
This PR enables configurations coming from environment variables that represent multiple values to be stored as a vector in `config.edn`, which is not supported by aero config as of now. An example of such variable:
`ALLOWED_ORIGINS="https://domain.a.com, https://domain.b.com"`

It's expected that env variables are comma-separated strings.
Their configs should have a `#csv` tag literal.
Trailing commas and whitespaces are handled.