### PR TITLE
feat: health endpoint

### DIFF
--- a/src/codes/clj/docs/backend/ports/http_in/ops.clj
+++ b/src/codes/clj/docs/backend/ports/http_in/ops.clj
@@ -1,0 +1,5 @@
+(ns codes.clj.docs.backend.ports.http-in.ops)
+
+(defn health
+  [_]
+  {:status 200 :body "OK"})

--- a/src/codes/clj/docs/backend/routes.clj
+++ b/src/codes/clj/docs/backend/routes.clj
@@ -1,6 +1,7 @@
 (ns codes.clj.docs.backend.routes
   (:require [codes.clj.docs.backend.interceptors :as backend.interceptors]
             [codes.clj.docs.backend.ports.http-in.document :as ports.http-in.document]
+            [codes.clj.docs.backend.ports.http-in.ops :as ports.http-in.ops]
             [codes.clj.docs.backend.ports.http-in.social :as ports.http-in.social]
             [codes.clj.docs.backend.schemas.wire.in.social :as schemas.wire.in.social]
             [codes.clj.docs.backend.schemas.wire.out.document :as schemas.wire.out.document]
@@ -14,6 +15,15 @@
            :swagger {:info {:title "clj.docs"
                             :description "codes.clj.docs.backend"}}
            :handler (swagger/create-swagger-handler)}}]
+
+   ["/ops"
+    {:swagger {:tags ["ops"]}}
+
+    ["/health"
+     {:get {:summary "health check"
+            :responses {200 {:body :string}
+                        500 {:body :string}}
+            :handler ports.http-in.ops/health}}]]
 
    ["/api"
 

--- a/test/integration/codes/clj/docs/backend/ops_test.clj
+++ b/test/integration/codes/clj/docs/backend/ops_test.clj
@@ -1,0 +1,20 @@
+(ns integration.codes.clj.docs.backend.ops-test
+  (:require [clojure.test :refer [use-fixtures]]
+            [integration.codes.clj.docs.backend.util :as util]
+            [parenthesin.helpers.malli :as helpers.malli]
+            [parenthesin.helpers.state-flow.server.pedestal :as state-flow.server]
+            [state-flow.api :refer [defflow flow]]
+            [state-flow.assertions.matcher-combinators :refer [match?]]))
+
+(use-fixtures :once helpers.malli/with-intrumentation)
+
+(defflow
+  flow-integration-ops-test
+  {:init util/start-system!
+   :cleanup util/stop-system!
+   :fail-fast? true}
+  (flow "should interact with system"
+    (flow "health check"
+      (match? {:status 200 :body "OK"}
+              (state-flow.server/request! {:method :get
+                                           :uri    "/ops/health"})))))


### PR DESCRIPTION
This PR adds an ops endpoint for automated health checks.
This endpoint can be used for readiness, liveness and startup probes by container orchestration platforms (e.g. Kubernetes).